### PR TITLE
Support CodeceptJS 4.x (ESM) when resolving the base Helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const dbjs = require('database-js');
 if ( ! Helper ) {
     var Helper = require( 'codeceptjs/lib/helper' );
+    // ESM interop: codeceptjs 4.x is ESM; require() of it returns the module namespace, extract default
+    if (Helper && typeof Helper !== 'function' && typeof Helper.default === 'function') Helper = Helper.default;
 }
 
 /**


### PR DESCRIPTION
### Problem

CodeceptJS 4.x is published as an **ESM** package. When `codeceptjs-dbhelper` is loaded under it, `require('codeceptjs/lib/helper')` returns the module **namespace object** (`{ default: Helper }`) rather than the `Helper` class itself. As a result:

```js
class DbHelper extends Helper { ... }
//                      ^^^^^^ TypeError: Class extends value #<Object> is not a constructor or null
```

The helper currently can't be used with CodeceptJS 4.x at all.

### Fix

Detect the namespace shape at runtime and unwrap `.default`:

```js
if ( ! Helper ) {
    var Helper = require( 'codeceptjs/lib/helper' );
    // ESM interop: codeceptjs 4.x is ESM; require() of it returns the module namespace, extract default
    if (Helper && typeof Helper !== 'function' && typeof Helper.default === 'function') Helper = Helper.default;
}
```

### Backward compatibility

The guard is a **no-op on CodeceptJS 3.x**, where `require()` already returns the class directly (a function), so `typeof Helper !== 'function'` is false and the line is skipped. The same single build keeps working across both major versions — nothing else changes.

We've been running this as a local `pnpm patch` against `codeceptjs-dbhelper@1.2.2` and would love to drop the patch in favour of an upstream release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)